### PR TITLE
empty pfdocs after a save failure

### DIFF
--- a/lib/logship.js
+++ b/lib/logship.js
@@ -98,6 +98,7 @@ PostfixToElastic.prototype.doneQueue = function(err, done) {
             return p2e.shutdown();
         }
         setTimeout(function () {
+            p2e.pfDocs = {};
             p2e.queueActive = false;
             p2e.doQueue(done);  // retry
         }, 60 * 1000);
@@ -144,7 +145,7 @@ PostfixToElastic.prototype.doQueue = function(done) {
 
             p2e.saveResultsToEs(function (err, res) {
                 logger.debug('\tsaveResultsToEs returned');
-                if (err) return p2e.doneQueue(err);
+                if (err) return p2e.doneQueue(err, done);
                 logger.info('\tsaveResultsToEs: ok');
                 p2e.doneQueue(null, done);
             });


### PR DESCRIPTION
net result: pfdocs get entirely reassembled after an ES  save failure.
This is less efficient than, say, trying to update only the docs that
failed, but this way a single retry mechanism suffices for any kind of
failure.