### PR TITLE
save postfix docs with parents

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,15 @@
 
+# 0.9.7 - 2015-12-09
+
+    - improved config file selection and loading
+    - save to parent index (if defined and available)
+    - moved startReader() into new function
+    - when searching for doc matches, limit to time series indexes covering the date of the postfix docs read.
+    - WARNING: due to above, config file options have changed. You **MUST** update your config file!
+        - `indices` option removed
+        - `timeformat` added.
+        - index names are automatically appended with `timeformat` suffix
+
 # 0.9.6 - 2015-11-18
 
     - honor the batchDelay setting

--- a/lib/logship.js
+++ b/lib/logship.js
@@ -16,32 +16,23 @@ var pfDoc     = require('./postfix-doc');
 var spool     = require('./spool');
 
 function PostfixToElastic (etcDir) {
-  this.cfg          = config(etcDir);
-  this.postdoc      = pfDoc(this.cfg);
-  this.spoolDir     = this.cfg.main.spool || '/var/spool/log_ship/postfix';
-  this.batchLimit   = this.cfg.reader.batchLimit || 1024;
-  this.batchDelay   = this.cfg.reader.batchDelay;
-  if (this.batchDelay === undefined) this.batchDelay = 5;
-  this.batchTries   = 0;
+  this.loadConfig(etcDir);
 
+  this.postdoc      = pfDoc(this.cfg);
+  this.batchTries   = 0;
   this.queue        = [];     // parsed lines stored here
   this.pfDocs       = {};     // postfix docs assembled here
   this.queueActive  = false;  // true while queue is being drained
   this.elasticAlive = false;
   this.watchdog();
 
-  spool.isValidDir(this.spoolDir);  // initialize spool dir
+  spool.isValidDir(this.cfg.main.spool);  // initialize spool dir
+
+  this.tryLoadingRedis();
 
   // initialize Elasticsearch
-  var esm       = require(this.cfg.elastic.module);
+  var esm = require(this.cfg.elastic.module);
   this.elastic = new esm.Client(this.getEsOpts());
-
-  var readerOpts = {
-    batchLimit: this.batchLimit,
-    bookmark: { dir: path.resolve(this.spoolDir, '.bookmark') },
-    watchDelay: this.cfg.reader.watchDelay,
-    batchDelay: this.batchDelay,
-  };
 
   var p2e = this;
   this.elastic.ping(function (err) {
@@ -51,32 +42,85 @@ function PostfixToElastic (etcDir) {
     }
 
     p2e.elasticAlive = true;
-
-    // elasticsearch is up, start reading lines
-    var read = require(p2e.cfg.reader.module);
-    p2e.reader = read.createReader(p2e.cfg.reader.file, readerOpts)
-    .on('readable', function () {
-      // log file is readable, read a line (see 'read' event)
-      this.readLine();  // 'this' is a reader
-    })
-    .on('read', function (data, lineCount) {
-      // logger.debug(lineCount + ': ' + data);
-      var parsed = p2e.postdoc.parseLine(data, lineCount);
-      if (!parsed) return;
-      if (!parsed.qid) {
-        logger.debug('ignoring: ' + data);
-        return;
-      }
-      p2e.queue.push(parsed);
-    })
-    .on('drain', function (done) {
-      p2e.doQueue(done);
-    })
-    .on('end', function () {
-      logger.info('end of file');
-    });
+    p2e.setReaderOpts();
+    p2e.startReader();
   });
 }
+
+PostfixToElastic.prototype.loadConfig = function(etcDir) {
+  this.cfg = config(etcDir);
+
+  if (!this.cfg.elastic.timeformat) {
+    this.cfg.elastic.timeformat = 'YYYY-MM-DD';
+  }
+  if (!this.cfg.main.spool) {
+    this.cfg.main.spool = '/var/spool/log_ship/postfix';
+  }
+  if (this.cfg.reader.batchDelay === undefined) {
+    this.cfg.reader.batchDelay = 5;
+  }
+  if (!this.cfg.reader.batchLimit) {
+    this.batchLimit = 1024;
+  }
+};
+
+PostfixToElastic.prototype.tryLoadingRedis = function() {
+  if (!this.cfg.redis) return;
+  if (!this.cfg.redis.module) return;
+  try {
+    var redis = require(this.cfg.redis.module);
+    this.redis = redis.createClient({
+      host: this.cfg.redis.host || '127.0.0.1',
+      port: this.cfg.redis.port || 6379,
+    });
+    this.redis.on('error', function (err) {
+      logger.error(err);
+    });
+    if (this.cfg.redis.db !== undefined) {
+      this.redis.select(this.cfg.redis.db);
+    }
+  }
+  catch (err) {
+    logger.error(err.message);
+  }
+};
+
+PostfixToElastic.prototype.setReaderOpts = function() {
+  this.readerOpts = {
+    batchLimit: this.cfg.reader.batchLimit,
+    bookmark: { dir: path.resolve(this.cfg.main.spool, '.bookmark') },
+    watchDelay: this.cfg.reader.watchDelay,
+    batchDelay: this.cfg.reader.batchDelay,
+  };
+};
+
+PostfixToElastic.prototype.startReader = function() {
+  var p2e = this;
+
+  // elasticsearch is up, start reading lines
+  var read = require(p2e.cfg.reader.module);
+  p2e.reader = read.createReader(p2e.cfg.reader.file, p2e.readerOpts)
+  .on('readable', function () {
+    // log file is readable, read a line (see 'read' event)
+    this.readLine();  // 'this' is a reader
+  })
+  .on('read', function (data, lineCount) {
+    // logger.debug(lineCount + ': ' + data);
+    var parsed = p2e.postdoc.parseLine(data, lineCount);
+    if (!parsed) return;
+    if (!parsed.qid) {
+      logger.debug('ignoring: ' + data);
+      return;
+    }
+    p2e.queue.push(parsed);
+  })
+  .on('drain', function (done) {
+    p2e.doQueue(done);
+  })
+  .on('end', function () {
+    logger.info('end of file');
+  });
+};
 
 PostfixToElastic.prototype.getEsOpts = function () {
   var esOpts = {
@@ -120,7 +164,7 @@ PostfixToElastic.prototype.doneQueue = function(err, done) {
   p2e.queueActive = false;
   p2e.batchTries = 0;
   logger.debug('\t\tqueue reset');
-  if (done) done(null, p2e.batchDelay);  // resume sending lines
+  if (done) done(null, p2e.cfg.reader.batchDelay);  // resume sending lines
 };
 
 PostfixToElastic.prototype.doQueue = function(done) {
@@ -147,19 +191,44 @@ PostfixToElastic.prototype.doQueue = function(done) {
   this.batchTries++;
 
   logger.info('doQueue: ' + this.queue.length + ' lines');
-  p2e.populatePfdocsFromEs(function (err, res) {
+  p2e.populatePfdocsFromEs(function (err) {
     if (err) return p2e.doneQueue(err);
 
     // update pfDocs with log entries
-    p2e.updatePfDocs(function (err, res) {
-
-      p2e.saveResultsToEs(function (err, res) {
-        logger.debug('\tsaveResultsToEs returned');
-        if (err) return p2e.doneQueue(err, done);
-        logger.info('\tsaveResultsToEs: ok');
-        p2e.doneQueue(null, done);
+    p2e.updatePfDocs(function () {
+      p2e.getParentIds(function () {
+        p2e.saveResultsToEs(function (err, res) {
+          logger.debug('\tsaveResultsToEs returned');
+          if (err) return p2e.doneQueue(err, done);
+          logger.info('\tsaveResultsToEs: ok');
+          p2e.doneQueue(null, done);
+        });
       });
     });
+  });
+};
+
+PostfixToElastic.prototype.getParentIds = function(done) {
+  var p2e = this;
+
+  if (!this.redis) {
+    logger.info('getParentIds() skipping, no redis');
+    return done();
+  }
+
+  var sameOrderAsRedisReply = [];
+  Object.keys(p2e.pfDocs).forEach(function (docId) {
+    sameOrderAsRedisReply.push(docId);
+  });
+
+  this.redis.mget(sameOrderAsRedisReply, function (err, replies) {
+    for (var i = 0; i < replies.length; i++) {
+      if (!replies[i]) continue;
+      logger.debug('parent reply ' + i + ': ' + replies[i]);
+      p2e.pfDocs[ sameOrderAsRedisReply[i] ]._parent = replies[i];
+    }
+
+    done();
   });
 };
 
@@ -167,35 +236,38 @@ PostfixToElastic.prototype.populatePfdocsFromEs = function(done) {
   var p2e = this;
   var pfQids = {};
 
+  // get a (likely short) list of elastic time series indexes in which these
+  // postfix documents would reside. This signficantly reduces the search cost
+  var uniqYMDs = {}; // to reduce index search space
+
   for (var i = 0; i < this.queue.length; i++) {
     pfQids[ this.queue[i].qid ] = true;
+    var df = moment(this.queue[i].date).format(p2e.cfg.elastic.timeformat);
+    uniqYMDs[ df ] = true;
   }
 
-  var uniqueQids = Object.keys(pfQids);
-  if (uniqueQids.length === 0) {
-    return done('no qids in new logs');
-  }
-  logger.debug('\tunique queue IDs: ' + uniqueQids.length);
+  var uniqIndexNames = [];
+  Object.keys(uniqYMDs).forEach(function (ymd) {
+    uniqIndexNames.push(p2e.cfg.elastic.index + '-' + ymd);
+    if (p2e.cfg.elastic.parent && p2e.cfg.elastic.parent.index) {
+      uniqIndexNames.push(p2e.cfg.elastic.parent.index + '-' + ymd);
+    }
+  });
 
   // get all pfQids from ES index
   this.elastic.search({
-    index: p2e.cfg.elastic.indices || 'postfix-orphan*',
-    type: p2e.cfg.elastic.type,
-    size: p2e.batchLimit * 3,
+    index: uniqIndexNames,
+    ignoreUnavailable: true,
+    // type: p2e.cfg.elastic.type,
+    size: p2e.cfg.reader.batchLimit * 3,
     body: {
       filter: {
-        terms: { _id: uniqueQids }
+        terms: { _id: Object.keys(pfQids) }
       }
     }
   },
   function (err, res) {
-    if (err) {
-      if (/^IndexMissing/.test(err.message)) {
-        // the index will get created when we insert a document
-        return done(null);
-      }
-      return done(err);
-    }
+    if (err) return done(err);
 
     logger.info('\telastic doc matches: ' + res.hits.total);
     // logger.debug(util.inspect(res.hits, {depth:null}));
@@ -205,6 +277,9 @@ PostfixToElastic.prototype.populatePfdocsFromEs = function(done) {
       var qid = res.hits.hits[i]._id;
       p2e.pfDocs[qid] = res.hits.hits[i]._source;
       p2e.pfDocs[qid]._index = res.hits.hits[i]._index;
+      if (res.hits.hits[i]._parent) {
+        p2e.pfDocs[qid]._parent = res.hits.hits[i]._parent;
+      }
       var version = res.hits.hits[i]._version;
       if (version) {
         logger.debug('qid: ' + qid + ' ver: ' + version);
@@ -246,15 +321,25 @@ PostfixToElastic.prototype.saveResultsToEs = function(done) {
   var esBulk = [];  // index, create, update
 
   Object.keys(p2e.pfDocs).forEach(function (qid) {
-    var doc = p2e.pfDocs[qid];
+    var doc = p2e.pfDocs[qid];     // this doc
 
     var bulkMeta = {
-      _index: doc._index || p2e.getIndexName(doc.date),
-      _type: p2e.cfg.elastic.type,
       _id: qid,
     };
-
     if (doc.qid) delete doc.qid;  // redundant
+
+    var dateSuffix = moment(doc.date).format(p2e.cfg.elastic.timeformat);
+
+    if (doc._parent && p2e.cfg.elastic.parent) {
+      bulkMeta._parent = doc._parent;
+      delete doc._parent;
+      bulkMeta._index  = p2e.cfg.elastic.parent.index + '-' + dateSuffix;
+      bulkMeta._type = p2e.cfg.elastic.parent.type;
+    }
+    else {
+      bulkMeta._index  = p2e.cfg.elastic.index + '-' + dateSuffix;
+      bulkMeta._type = p2e.cfg.elastic.type;
+    }
 
     if (doc._index) {
       delete doc._index;
@@ -286,21 +371,6 @@ PostfixToElastic.prototype.saveResultsToEs = function(done) {
     }
     done(null, res);
   });
-};
-
-PostfixToElastic.prototype.getIndexName = function(date) {
-
-  var name = this.cfg.elastic.index || 'postfix-orphan';
-  if (!/-(?:YYYY|MM|DD)/.test(name)) return name;
-
-  // http://momentjs.com/docs/#/get-set/get/
-  date = moment(date);
-
-  name = name.replace(/\-YYYY/, '-' + date.format('YYYY'));
-  name = name.replace(/\-MM/,   '-' + date.format('MM'));
-  name = name.replace(/\-DD/,   '-' + date.format('DD'));
-
-  return name;
 };
 
 PostfixToElastic.prototype.shutdown = function() {

--- a/log-ship-elastic-postfix.ini
+++ b/log-ship-elastic-postfix.ini
@@ -7,9 +7,14 @@ spool=/var/spool/log_ship/postfix
 [elastic]
 module=elasticsearch
 hosts=es1:9200, es2:9200, es3:9200
-index=postfix-orphan-YYYY-MM-DD
-indices=postfix-orphan*
+timeformat=YYYY-MM-DD
+
+index=postfix-orphan
 type=postfix-orphan
+
+[elastic.parent]
+index=postfix
+type=postfix
 
 
 [parser]
@@ -33,3 +38,11 @@ batchLimit=1024
 ; how many seconds to pause between batches. General rule of thumb:
 ; concurrent postfix log shippers / elasticsearch indexers
 batchDelay=5
+
+
+[redis]
+; uncomment the module line to enable
+; module=redis
+; host=127.0.0.1
+; port=6379
+; db=1

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "log-ship-elastic-postfix",
   "description": "Ship normalized Postfix logs to Elasticsearch",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "private": false,
   "keywords": [
-    "log", "postfix", "elasticsearch", "log ship"
+    "log",
+    "postfix",
+    "elasticsearch",
+    "log ship"
   ],
   "homepage": "https://github.com/DoubleCheck/log-ship-elastic-postfix",
   "bugs": {
@@ -19,6 +22,7 @@
     "ini": "^1.3.4",
     "moment-timezone": "*",
     "postfix-parser": ">=1.0.4",
+    "redis": "^2.4.2",
     "safe-log-reader": ">=0.9.9"
   },
   "devDependencies": {
@@ -43,7 +47,7 @@
       "threshold": 80
     }
   },
-  "license" : "BSD-2-Clause",
+  "license": "BSD-2-Clause",
   "scripts": {
     "start": "node server.js",
     "test": "NODE_ENV=test mocha"

--- a/test/log-ship-elastic-postfix.ini
+++ b/test/log-ship-elastic-postfix.ini
@@ -9,6 +9,9 @@ module=elasticsearch
 hosts=localhost:9200
 index=postfix-orphans
 
+; index for documents with parents
+parent=postfix
+
 ; how many log lines to parse and queue before starting the batch
 ; batch: get matching queue IDs from ES, update/create docs, save to ES
 batch=1024

--- a/test/logship.js
+++ b/test/logship.js
@@ -78,35 +78,4 @@ describe('log-ship-elastic-postfix', function () {
       });
     });
   });
-
-  describe('getIndexName', function () {
-
-    // date is a moment.js object: http://momentjs.com/docs/#/get-set/get/
-    var date = moment('Jul 26 04:18:34', 'MMM DD HH:mm:ss');
-    var y = date.format('YYYY');
-    var m = date.format('MM');
-    var d = date.format('DD');
-
-    it('returns a static index name', function () {
-      shipper.cfg.elastic.index='postfix-orphan';
-      assert.equal(shipper.getIndexName(date), 'postfix-orphan');
-    });
-
-    it('date template year', function () {
-      shipper.cfg.elastic.index='postfix-orphan-YYYY';
-      assert.equal(shipper.getIndexName(date), 'postfix-orphan-' + y);
-    });
-
-    it('date template month', function () {
-      shipper.cfg.elastic.index='postfix-orphan-YYYY-MM';
-      assert.equal(shipper.getIndexName(date), 'postfix-orphan-' + y + '-' + m);
-    });
-
-    it('date template day', function () {
-      shipper.cfg.elastic.index='postfix-orphan-YYYY-MM-DD';
-      assert.equal(
-        shipper.getIndexName(date),
-        'postfix-orphan-' + y + '-' + m + '-' + d);
-    });
-  });
 });


### PR DESCRIPTION
# work in progress

* fetch postfix docs from both indexes (parented and orphans)
* refactor parts of PostfixToElastic() into a couple smaller functions (it was getting rather unwieldy)
* get postfix parents from Redis …
    * add optional redis loading
    * look up parent IDs in redis
    * save docs with parents to ES parent index

connected to dc/webui#339